### PR TITLE
Rely on VolumeClaimTemplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,23 @@ We are currently verifying 'microshift' and Code Ready Containers for local deve
 
 ## Installation
 
+During the installation, some of the steps are specific to a regular Kubernetes cluster, while others are specific to Kind clusters. 
+
+### Install Tekton Operator
+
 Install the tekton cli and tekton resources before continuing (see https://tekton.dev/docs/pipelines/install)
 
-Clone the repository
+### Clone the repository
 
 ```bash
 git clone git@github.com:okd-project/pipelines.git
 ```
 
-Install the storage provisioner 
+### Install the storage provisioner (All clusters)
 
 This example uses an NFS provisioner for an on-prem kubernetes cluster 
 
-Skip this step (go to Install the operator tekton pipeline section) if you already have storage (persistent volumes and persistent volume claims and provisioner) setup
+Skip this step (go to [Install the operator tekton pipeline with kustomize](###install-the-operator-tekton-pipeline-with-kustomize)) if you already have storage (storageClass and provisioner) setup, as it is the case on Kind clusters for example, with the `standard` storageClass.
 
 **NB** Before executing the provisioner, change the fields that relate to your specific
 NFS setup i.e server name (ip) and path in the file environments/overlays/nfs-provisioner/patch_nfs_details.yaml
@@ -155,7 +159,16 @@ kubectl get pv
 # assume the provisioner has a storageClass called standard
 find environments/overlays/cicd/pvc/. -type f -name '*pvc*' | xargs sed -i 's/nfs-client/standard/g'
 ```
-Install the operator tekton pipeline with kustomize
+
+### Install the operator tekton pipeline with kustomize
+
+__Note__: For Kind clusters, or when using VolumeClaimTemplate, start by commenting the following lines from the `resources` list in `environments/overlays/cicd/kustomization.yaml`:
+```yaml
+resources:
+  - namespace/namespace.yaml
+#  - pvc/pipeline-pvc.yaml
+#  - pvc/build-cache-pvc.yaml
+```
 
 Execute the following commands
 
@@ -165,6 +178,7 @@ kubectl apply -k environments/overlays/cicd
 
 # check that all resources have deployed
 kubectl get all -n operator-pipeline
+# If not running on Kind, also check PVCs are available
 kubectl get pvc -n operator-pipeline
 
 # once all pods are in the RUNNING status create a configmap as follows
@@ -174,6 +188,8 @@ kubectl create configmap docker-config --from-file=/$HOME/.docker/config.json -n
 
 ## Usage
 
+### Option 1 - On clusters with existing PVCs
+
 Execute the following to start a pipeline run
 
 ```bash
@@ -181,11 +197,23 @@ Execute the following to start a pipeline run
 tkn pipeline start pipeline-dev-all \
 --param repo-url=https://github.com/openshift/node-observability-operator \
 --param repo-name=node-observability-operator \
---param base-image-registry=quay.io/<your-repo-id>
---param bundle-version=v0.0.1
+--param base-image-registry=quay.io/<your-repo-id> \
+--param bundle-version=v0.0.1 \
 --workspace name=shared-workspace,claimName=pipeline-pvc-dev
-
 ```
+
+### Option 2 - Kind clusters, or without existing PVCs
+
+```bash
+# example (using the node-observability-operator)
+tkn pipeline start pipeline-dev-all \
+--param repo-url=https://github.com/openshift/node-observability-operator \
+--param repo-name=node-observability-operator \
+--param base-image-registry=quay.io/<your-repo-id> \
+--param bundle-version=v0.0.1 \
+--workspace name=shared-workspace,volumeClaimTemplateFile=workspace-template.yaml
+```
+
 
 ## Dockerfile
 
@@ -277,4 +305,9 @@ The folder structure is as follows :
                               |    
                               --- pipeline-dev.yaml
                               --- pipeline-dev-all.yaml
+                              --- kustomization.yaml
+                  --- pipelineruns
+                        |
+                        --- sample-pr-dev-all-on-kind.yaml
+                        --- workspace-template.yaml
 ```

--- a/environments/overlays/cicd/kustomization.yaml
+++ b/environments/overlays/cicd/kustomization.yaml
@@ -7,7 +7,5 @@ bases:
   - ../../../manifests/tekton/pipelines/base
 resources:
   - namespace/namespace.yaml
-  - pvc/pipeline-pvc.yaml
-  - pvc/build-cache-pvc.yaml
 namespace: operator-pipeline
 

--- a/environments/overlays/cicd/kustomization.yaml
+++ b/environments/overlays/cicd/kustomization.yaml
@@ -7,5 +7,7 @@ bases:
   - ../../../manifests/tekton/pipelines/base
 resources:
   - namespace/namespace.yaml
+  - pvc/pipeline-pvc.yaml
+  - pvc/build-cache-pvc.yaml
 namespace: operator-pipeline
 

--- a/manifests/tekton/pipelineruns/sample-pr-dev-all-on-kind.yaml
+++ b/manifests/tekton/pipelineruns/sample-pr-dev-all-on-kind.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  namespace: operator-pipeline
+  name: my-dev-all
+spec:
+  podTemplate:
+    nodeSelector:
+      kubernetes.io/hostname: kind-control-plane
+  params:
+  - name: base-image-registry
+    value: quay.io/skhoury
+  - name: bundle-version
+    value: v0.0.1
+  - name: repo-name
+    value: node-observability-operator
+  - name: repo-url
+    value: https://github.com/openshift/node-observability-operator
+  pipelineRef:
+    name: pipeline-dev-all
+
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        storageClassName: standard
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/manifests/tekton/pipelineruns/sample-pr-dev-all-on-kind.yaml
+++ b/manifests/tekton/pipelineruns/sample-pr-dev-all-on-kind.yaml
@@ -9,7 +9,7 @@ spec:
       kubernetes.io/hostname: kind-control-plane
   params:
   - name: base-image-registry
-    value: quay.io/skhoury
+    value: quay.io/username
   - name: bundle-version
     value: v0.0.1
   - name: repo-name

--- a/manifests/tekton/pipelineruns/workspace-template.yaml
+++ b/manifests/tekton/pipelineruns/workspace-template.yaml
@@ -1,0 +1,7 @@
+spec:
+  storageClassName: standard
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/manifests/tekton/pipelines/base/pipeline-dev-all.yaml
+++ b/manifests/tekton/pipelines/base/pipeline-dev-all.yaml
@@ -18,7 +18,7 @@ spec:
     type: string
   
   workspaces:
-    - name: shared-workspace
+  - name: shared-workspace
 
   tasks:
   - name: fetch-repository
@@ -50,6 +50,10 @@ spec:
       - name: bundle-version
         value: $(params.bundle-version)
     workspaces:
+      - name: build-cache-home
+        workspace: shared-workspace
+      - name: build-cache-root
+        workspace: shared-workspace
       - name: src
         workspace: shared-workspace
 
@@ -66,4 +70,8 @@ spec:
         value: $(params.bundle-version)
     workspaces:
       - name: src
+        workspace: shared-workspace
+      - name: build-cache-home
+        workspace: shared-workspace
+      - name: build-cache-root
         workspace: shared-workspace

--- a/manifests/tekton/tasks/base/bundle-all.yaml
+++ b/manifests/tekton/tasks/base/bundle-all.yaml
@@ -15,7 +15,11 @@ spec:
     type: string
  
   workspaces:
-    - name: src
+  - name: src
+  - name: build-cache-root
+    mountPath: /root
+  - name: build-cache-home
+    mountPath: /home/1001
       
   steps: 
   - name: bundle
@@ -25,11 +29,6 @@ spec:
     args: ["bundle","OPERATOR_SDK_BIN=/usr/bin/operator-sdk","KUSTOMIZE=/usr/bin/kustomize","IMG=$(params.base-image-registry)/$(params.repo-name)-bundle:$(params.bundle-version)"]
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
 
   - name: bundle-dockerfile-check
     image: quay.io/okd/go-bundle-tools:v1.0.0
@@ -44,11 +43,6 @@ spec:
       fi
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
 
   
   - name: bundle-image-push
@@ -72,11 +66,6 @@ spec:
       cat index.Dockerfile
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
  
   - name: index-image-push
     workingDir: /workspace/src/$(params.repo-name)
@@ -116,11 +105,6 @@ spec:
       cat catalog.Dockerfile
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
 
   - name: catalog-image-push
     workingDir: /workspace/src/$(params.repo-name)
@@ -137,7 +121,4 @@ spec:
   - name: docker-config
     configMap:
       name: docker-config
-  - name: build-cache
-    persistentVolumeClaim:
-      claimName: build-cache-pvc-dev
 

--- a/manifests/tekton/tasks/base/container-all.yaml
+++ b/manifests/tekton/tasks/base/container-all.yaml
@@ -15,7 +15,11 @@ spec:
     type: string
  
   workspaces:
-    - name: src
+  - name: src
+  - name: build-cache-root
+    mountPath: /root
+  - name: build-cache-home
+    mountPath: /home/1001
       
   steps: 
   - name: verify
@@ -82,11 +86,6 @@ spec:
     workingDir: /workspace/src/$(params.repo-name)
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
   
   - name: unit-test
     image: quay.io/okd/go-bundle-tools:v1.0.0
@@ -96,11 +95,6 @@ spec:
     args: ["test"]
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
 
   - name: build
     image: quay.io/okd/go-bundle-tools:v1.0.0
@@ -116,11 +110,6 @@ spec:
     args: ["build-operator"]
     securityContext:
       runAsUser: 0
-    volumeMounts:
-    - name: build-cache
-      mountPath: /home/1001
-    - name: build-cache
-      mountPath: /root
 
   - name: runtime-docker
     workingDir: /workspace/src/$(params.repo-name)
@@ -159,7 +148,4 @@ spec:
   - name: docker-config
     configMap:
       name: docker-config
-  - name: build-cache
-    persistentVolumeClaim:
-      claimName: build-cache-pvc-dev
 

--- a/manifests/tekton/triggers/base/trigger-binding-dev.yaml
+++ b/manifests/tekton/triggers/base/trigger-binding-dev.yaml
@@ -12,3 +12,5 @@ spec:
     value: $(body.version)
   - name: base-image-registry
     value: $(body.imageregistry)
+  - name: storage-class-name
+    value: $(body.storageclassname)

--- a/manifests/tekton/triggers/base/trigger-template-dev.yaml
+++ b/manifests/tekton/triggers/base/trigger-template-dev.yaml
@@ -12,6 +12,8 @@ spec:
     description: bundle version (v0.0.1)
   - name: base-image-registry
     description: base image registry
+  - name: storage-class-name
+    description: StorageClass used for PVCs
   
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
@@ -33,5 +35,11 @@ spec:
         
       workspaces:
       - name: shared-workspace
-        persistentVolumeClaim:
-          claimName: pipeline-pvc-dev
+        volumeClaimTemplate:
+          spec:
+            storageClassName: $(tt.params.storage-class-name)
+            accessModes:
+            - ReadWriteOnce
+            resources: 
+              requests:
+                storage: 1Gi


### PR DESCRIPTION
This PR is the result of the POC on kind, with which I relied on VolumeClaimTemplates:
* The PVCs in environment/overlays/cicd are only necessary in case we're not using VolumeClaimTemplates
* All tasks in the pipeline use the same workspace, `shared-workspace`
* Not at all sure about the triggers => to be reviewed
* Added a sample pipelinerun, which defines the workspace using the `VolumeClaimTemplate`, which relies on storageclass `standard`, which is available by default with `kind` clusters. Note the use of a `podTemplate` also in the pipelineRun, which selects the _single_ node on which the pvc should be created.
* Updated the README with instructions on both use with specific volumeClaims and with VolumeClaimTemplates

