### PR TITLE
[nmstate] Remove ImageStream from bundle manifests

### DIFF
--- a/nmstate/build.sh
+++ b/nmstate/build.sh
@@ -58,6 +58,9 @@ build_bundle() {
      "BUNDLE_METADATA_OPTS=${BUNDLE_METADATA_OPTS}" MANIFEST_BASES_DIR=manifests/bases MONITORING_NAMESPACE=openshift-monitoring \
      HANDLER_NAMESPACE=$namespace OPERATOR_NAMESPACE=$namespace PLUGIN_NAMESPACE=$namespace
 
+    # Remove ImageStream — it's an OpenShift build artifact not supported by OKD's OLM
+    find manifests/stable -name '*.yaml' -exec grep -l 'kind: ImageStream' {} \; | xargs rm -f
+
     podman build -f manifests/stable/bundle.Dockerfile -t "${IMG_BUNDLE}" .
     podman push "${IMG_BUNDLE}"
 


### PR DESCRIPTION
The `make ocp-update-bundle-manifests` step injects an ImageStream manifest into the bundle. This is an OpenShift build artifact — the CSV already references all container images by digest, so the ImageStream serves no runtime purpose. OKD 4.20 marks it as UnsupportedResource, causing the InstallPlan to fail immediately.

Fixes: https://github.com/okd-project/okderators-catalog-index/issues/45