### PR TITLE
Add per-operator deploy workflows for all operators

### DIFF
--- a/.github/workflows/acm-deploy.yaml
+++ b/.github/workflows/acm-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'acm/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy ACM
+
+jobs:
+  deploy:
+    name: Deploy ACM
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: acm
+    secrets: inherit

--- a/.github/workflows/cluster-logging-deploy.yaml
+++ b/.github/workflows/cluster-logging-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'cluster-logging/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Cluster-Logging
+
+jobs:
+  deploy:
+    name: Deploy Cluster-Logging
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: cluster-logging
+    secrets: inherit

--- a/.github/workflows/cluster-observability-deploy.yaml
+++ b/.github/workflows/cluster-observability-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'cluster-observability/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Cluster-Observability
+
+jobs:
+  deploy:
+    name: Deploy Cluster-Observability
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: cluster-observability
+    secrets: inherit

--- a/.github/workflows/data-foundation-deploy.yaml
+++ b/.github/workflows/data-foundation-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'data-foundation/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Data-Foundation
+
+jobs:
+  deploy:
+    name: Deploy Data-Foundation
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: data-foundation
+    secrets: inherit

--- a/.github/workflows/dev-spaces-deploy.yaml
+++ b/.github/workflows/dev-spaces-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'dev-spaces/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Dev-Spaces
+
+jobs:
+  deploy:
+    name: Deploy Dev-Spaces
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: dev-spaces
+    secrets: inherit

--- a/.github/workflows/devworkspace-deploy.yaml
+++ b/.github/workflows/devworkspace-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'devworkspace/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Devworkspace
+
+jobs:
+  deploy:
+    name: Deploy Devworkspace
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: devworkspace
+    secrets: inherit

--- a/.github/workflows/external-secrets-deploy.yaml
+++ b/.github/workflows/external-secrets-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'external-secrets/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy External-Secrets
+
+jobs:
+  deploy:
+    name: Deploy External-Secrets
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: external-secrets
+    secrets: inherit

--- a/.github/workflows/gitops-deploy.yaml
+++ b/.github/workflows/gitops-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'gitops/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy GitOps
+
+jobs:
+  deploy:
+    name: Deploy GitOps
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: gitops
+    secrets: inherit

--- a/.github/workflows/ingress-node-firewall-deploy.yaml
+++ b/.github/workflows/ingress-node-firewall-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'ingress-node-firewall/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Ingress-Node-Firewall
+
+jobs:
+  deploy:
+    name: Deploy Ingress-Node-Firewall
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: ingress-node-firewall
+    secrets: inherit

--- a/.github/workflows/local-storage-deploy.yaml
+++ b/.github/workflows/local-storage-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'local-storage/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Local-Storage
+
+jobs:
+  deploy:
+    name: Deploy Local-Storage
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: local-storage
+    secrets: inherit

--- a/.github/workflows/lvms-deploy.yaml
+++ b/.github/workflows/lvms-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'lvms/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy LVMS
+
+jobs:
+  deploy:
+    name: Deploy LVMS
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: lvms
+    secrets: inherit

--- a/.github/workflows/metallb-deploy.yaml
+++ b/.github/workflows/metallb-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'metallb/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Metallb
+
+jobs:
+  deploy:
+    name: Deploy Metallb
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: metallb
+    secrets: inherit

--- a/.github/workflows/multicluster-engine-deploy.yaml
+++ b/.github/workflows/multicluster-engine-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'multicluster-engine/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Multicluster-Engine
+
+jobs:
+  deploy:
+    name: Deploy Multicluster-Engine
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: multicluster-engine
+    secrets: inherit

--- a/.github/workflows/network-observability-deploy.yaml
+++ b/.github/workflows/network-observability-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'network-observability/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Network-Observability
+
+jobs:
+  deploy:
+    name: Deploy Network-Observability
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: network-observability
+    secrets: inherit

--- a/.github/workflows/nmstate-deploy.yaml
+++ b/.github/workflows/nmstate-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'nmstate/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy NMState
+
+jobs:
+  deploy:
+    name: Deploy NMState
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: nmstate
+    secrets: inherit

--- a/.github/workflows/node-feature-discovery-deploy.yaml
+++ b/.github/workflows/node-feature-discovery-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'node-feature-discovery/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Node-Feature-Discovery
+
+jobs:
+  deploy:
+    name: Deploy Node-Feature-Discovery
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: node-feature-discovery
+    secrets: inherit

--- a/.github/workflows/oadp-deploy.yaml
+++ b/.github/workflows/oadp-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'oadp/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy OADP
+
+jobs:
+  deploy:
+    name: Deploy OADP
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: oadp
+    secrets: inherit

--- a/.github/workflows/operator-deploy.yaml
+++ b/.github/workflows/operator-deploy.yaml
@@ -11,7 +11,7 @@ on:
         required: false
         default: "quay.io/okderators"
 
-name: Deploy Operattttor
+name: Deploy Operator
 
 jobs:
   deploy-operator:

--- a/.github/workflows/operator-updates.yaml
+++ b/.github/workflows/operator-updates.yaml
@@ -18,6 +18,8 @@ jobs:
           - cluster-logging
           - cluster-observability
           - data-foundation
+          - dev-spaces
+          - devworkspace
           - external-secrets
           - gitops
           - ingress-node-firewall
@@ -30,8 +32,10 @@ jobs:
           - node-feature-discovery
           - oadp
           - pf-status-relay
+          - ptp
           - service-mesh
           - sr-iov
+          - vertical-pod-autoscaler
           - web-terminal
 
     steps:

--- a/.github/workflows/pf-status-relay-deploy.yaml
+++ b/.github/workflows/pf-status-relay-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'pf-status-relay/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Pf-Status-Relay
+
+jobs:
+  deploy:
+    name: Deploy Pf-Status-Relay
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: pf-status-relay
+    secrets: inherit

--- a/.github/workflows/ptp-deploy.yaml
+++ b/.github/workflows/ptp-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'ptp/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy PTP
+
+jobs:
+  deploy:
+    name: Deploy PTP
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: ptp
+    secrets: inherit

--- a/.github/workflows/service-mesh-deploy.yaml
+++ b/.github/workflows/service-mesh-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'service-mesh/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Service-Mesh
+
+jobs:
+  deploy:
+    name: Deploy Service-Mesh
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: service-mesh
+    secrets: inherit

--- a/.github/workflows/sr-iov-deploy.yaml
+++ b/.github/workflows/sr-iov-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'sr-iov/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy SR-IOV
+
+jobs:
+  deploy:
+    name: Deploy SR-IOV
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: sr-iov
+    secrets: inherit

--- a/.github/workflows/vertical-pod-autoscaler-deploy.yaml
+++ b/.github/workflows/vertical-pod-autoscaler-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'vertical-pod-autoscaler/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Vertical-Pod-Autoscaler
+
+jobs:
+  deploy:
+    name: Deploy Vertical-Pod-Autoscaler
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: vertical-pod-autoscaler
+    secrets: inherit

--- a/.github/workflows/web-terminal-deploy.yaml
+++ b/.github/workflows/web-terminal-deploy.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - 'web-terminal/**'
+  workflow_dispatch: # Allow manual trigger
+
+name: Deploy Web-Terminal
+
+jobs:
+  deploy:
+    name: Deploy Web-Terminal
+    uses: ./.github/workflows/operator-deploy.yaml
+    with:
+      operator: web-terminal
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add deploy wrapper workflows for the 23 operators that were missing them, following the existing cert-manager pattern: each triggers on pushes to `main` touching its operator directory (plus `workflow_dispatch`) and calls the reusable `operator-deploy.yaml` with `secrets: inherit`
- Add the four operators missing from the weekly update matrix in `operator-updates.yaml`: `dev-spaces`, `devworkspace`, `ptp`, `vertical-pod-autoscaler` — the matrix now covers all 24 operators
- Fix "Deploy Operattttor" typo in the reusable workflow name

## Notes for reviewers
Once merged, any push to `main` touching an operator directory triggers a real build-and-push to Quay — including commits pushed by the weekly update workflow itself, so a Monday update run will trigger deploys for every operator it updated. This matches the existing cert-manager workflow behaviour; if that cascade is not desired, the wrappers would need a guard (e.g. skip `github-actions[bot]` commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)