### PR TITLE
Open a catalog index PR after operator builds

### DIFF
--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -1,0 +1,203 @@
+on:
+  workflow_call:
+    inputs:
+      bundle_images:
+        description: "Bundle image reference(s), whitespace- or newline-separated"
+        type: string
+        required: true
+      operator:
+        description: "Operator name/directory the bundles were built from (informational)"
+        type: string
+        required: false
+        default: ""
+      catalog_repo:
+        description: "Catalog index repository (owner/name)"
+        type: string
+        required: false
+        default: "okd-project/okderators-catalog-index"
+      catalog_branch:
+        description: "Catalog index branch to target with the PR"
+        type: string
+        required: false
+        default: "release-4.21"
+      channel:
+        description: "OLM channel used when the operator has no package file yet (existing packages use their defaultChannel)"
+        type: string
+        required: false
+        default: "alpha"
+    secrets:
+      CATALOG_PUSH_TOKEN:
+        description: "Token with permission to push branches and open PRs on the catalog index repository"
+        required: false
+  workflow_dispatch:
+    inputs:
+      bundle_images:
+        description: "Bundle image reference(s), whitespace-separated"
+        type: string
+        required: true
+      operator:
+        description: "Operator name/directory the bundles were built from (informational)"
+        type: string
+        required: false
+        default: ""
+      catalog_repo:
+        description: "Catalog index repository (owner/name)"
+        type: string
+        required: false
+        default: "okd-project/okderators-catalog-index"
+      catalog_branch:
+        description: "Catalog index branch to target with the PR"
+        type: string
+        required: false
+        default: "release-4.21"
+      channel:
+        description: "OLM channel used when the operator has no package file yet"
+        type: string
+        required: false
+        default: "alpha"
+
+name: Catalog Index PR
+
+jobs:
+  catalog-pr:
+    name: Open Catalog Index PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for catalog token
+        id: token
+        env:
+          TOKEN: ${{ secrets.CATALOG_PUSH_TOKEN }}
+        # language=bash
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::CATALOG_PUSH_TOKEN is not set; skipping catalog index PR"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.token.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Checkout catalog index
+        if: steps.token.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.catalog_repo }}
+          ref: ${{ inputs.catalog_branch }}
+          token: ${{ secrets.CATALOG_PUSH_TOKEN }}
+          path: catalog-index
+
+      - name: Install dependencies
+        if: steps.token.outputs.enabled == 'true'
+        # language=bash
+        run: |
+          # Install yq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+          # Install opm
+          sudo wget -qO /usr/local/bin/opm https://github.com/operator-framework/operator-registry/releases/latest/download/linux-amd64-opm
+          sudo chmod +x /usr/local/bin/opm
+
+      - name: Install Podman
+        if: steps.token.outputs.enabled == 'true'
+        uses: redhat-actions/podman-install@main
+
+      - name: Configure git
+        if: steps.token.outputs.enabled == 'true'
+        # language=bash
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Render bundles into catalog
+        if: steps.token.outputs.enabled == 'true'
+        id: render
+        env:
+          BUNDLE_IMAGES: ${{ inputs.bundle_images }}
+          CHANNEL: ${{ inputs.channel }}
+        # language=bash
+        run: |
+          cd catalog-index
+
+          BUNDLE_NAMES=""
+          for BUNDLE in $BUNDLE_IMAGES; do
+            echo "Rendering ${BUNDLE} into the catalog..."
+            ./hack/add-bundle.sh "$BUNDLE"
+
+            # Derive the CSV/bundle name the same way add-bundle.sh does
+            BUNDLE_NAME=$(opm render "$BUNDLE" -o yaml | yq 'select(.schema == "olm.bundle") | .name')
+            OPERATOR_NAME=${BUNDLE_NAME%%.*}
+
+            # Wire the new bundle into the package's channel upgrade graph
+            bash "$GITHUB_WORKSPACE/scripts/update-catalog-package.sh" \
+              "catalog/${OPERATOR_NAME}/${OPERATOR_NAME}.yaml" "$BUNDLE_NAME" "$CHANNEL"
+
+            BUNDLE_NAMES="${BUNDLE_NAMES} ${BUNDLE_NAME}"
+          done
+
+          echo "bundle_names=${BUNDLE_NAMES# }" >> "$GITHUB_OUTPUT"
+
+      - name: Validate catalog
+        if: steps.token.outputs.enabled == 'true'
+        # language=bash
+        run: |
+          cd catalog-index
+          opm validate catalog
+
+      - name: Create pull request
+        if: steps.token.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CATALOG_PUSH_TOKEN }}
+          CATALOG_REPO: ${{ inputs.catalog_repo }}
+          CATALOG_BRANCH: ${{ inputs.catalog_branch }}
+          BUNDLE_IMAGES: ${{ inputs.bundle_images }}
+          BUNDLE_NAMES: ${{ steps.render.outputs.bundle_names }}
+          OPERATOR: ${{ inputs.operator }}
+        # language=bash
+        run: |
+          cd catalog-index
+
+          if [ -z "$(git status --porcelain catalog)" ]; then
+            echo "Catalog already contains these bundles; nothing to do."
+            exit 0
+          fi
+
+          FIRST_NAME=$(echo "$BUNDLE_NAMES" | cut -d' ' -f1)
+          BRANCH="add-${FIRST_NAME//[^a-zA-Z0-9.-]/-}-${GITHUB_RUN_ID}"
+          TITLE="Add ${BUNDLE_NAMES// /, } to the catalog"
+
+          git checkout -b "$BRANCH"
+          git add catalog
+          git commit -m "$TITLE"
+          git push origin "$BRANCH"
+
+          {
+            echo "Adds the following bundle(s) to the catalog:"
+            echo ""
+            for NAME in $BUNDLE_NAMES; do
+              echo "- \`${NAME}\`"
+            done
+            echo ""
+            echo "Bundle image(s):"
+            echo ""
+            for IMAGE in $BUNDLE_IMAGES; do
+              echo "- \`${IMAGE}\`"
+            done
+            echo ""
+            if [ -n "$OPERATOR" ]; then
+              echo "Built from operator directory \`${OPERATOR}\` in \`${GITHUB_REPOSITORY}\`."
+            fi
+            echo "Rendered with \`hack/add-bundle.sh\`, channel entries updated, and validated with \`opm validate\` by [this workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          gh pr create \
+            --repo "$CATALOG_REPO" \
+            --base "$CATALOG_BRANCH" \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -26,8 +26,8 @@ on:
         required: false
         default: "alpha"
     secrets:
-      CATALOG_PUSH_TOKEN:
-        description: "Token with permission to push branches and open PRs on the catalog index repository"
+      CATALOG_APP_PRIVATE_KEY:
+        description: "Private key of the GitHub App used to push branches and open PRs on the catalog index repository (app id comes from the CATALOG_APP_ID variable)"
         required: false
   workflow_dispatch:
     inputs:
@@ -68,12 +68,30 @@ jobs:
         with:
           submodules: false
 
+      - name: Parse catalog repository
+        id: catalog
+        env:
+          CATALOG_REPO: ${{ inputs.catalog_repo }}
+        # language=bash
+        run: |
+          echo "owner=${CATALOG_REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${CATALOG_REPO##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Mint catalog token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CATALOG_APP_ID }}
+          private-key: ${{ secrets.CATALOG_APP_PRIVATE_KEY }}
+          owner: ${{ steps.catalog.outputs.owner }}
+          repositories: ${{ steps.catalog.outputs.name }}
+
       - name: Checkout catalog index
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.catalog_repo }}
           ref: ${{ inputs.catalog_branch }}
-          token: ${{ secrets.CATALOG_PUSH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: catalog-index
 
       - name: Install dependencies
@@ -131,7 +149,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.CATALOG_PUSH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CATALOG_REPO: ${{ inputs.catalog_repo }}
           CATALOG_BRANCH: ${{ inputs.catalog_branch }}
           BUNDLE_IMAGES: ${{ inputs.bundle_images }}

--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -63,27 +63,12 @@ jobs:
     name: Open Catalog Index PR
     runs-on: ubuntu-latest
     steps:
-      - name: Check for catalog token
-        id: token
-        env:
-          TOKEN: ${{ secrets.CATALOG_PUSH_TOKEN }}
-        # language=bash
-        run: |
-          if [ -n "$TOKEN" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::CATALOG_PUSH_TOKEN is not set; skipping catalog index PR"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout repository
-        if: steps.token.outputs.enabled == 'true'
         uses: actions/checkout@v4
         with:
           submodules: false
 
       - name: Checkout catalog index
-        if: steps.token.outputs.enabled == 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.catalog_repo }}
@@ -92,7 +77,6 @@ jobs:
           path: catalog-index
 
       - name: Install dependencies
-        if: steps.token.outputs.enabled == 'true'
         # language=bash
         run: |
           # Install yq
@@ -104,18 +88,15 @@ jobs:
           sudo chmod +x /usr/local/bin/opm
 
       - name: Install Podman
-        if: steps.token.outputs.enabled == 'true'
         uses: redhat-actions/podman-install@main
 
       - name: Configure git
-        if: steps.token.outputs.enabled == 'true'
         # language=bash
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Render bundles into catalog
-        if: steps.token.outputs.enabled == 'true'
         id: render
         env:
           BUNDLE_IMAGES: ${{ inputs.bundle_images }}
@@ -143,14 +124,12 @@ jobs:
           echo "bundle_names=${BUNDLE_NAMES# }" >> "$GITHUB_OUTPUT"
 
       - name: Validate catalog
-        if: steps.token.outputs.enabled == 'true'
         # language=bash
         run: |
           cd catalog-index
           opm validate catalog
 
       - name: Create pull request
-        if: steps.token.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ secrets.CATALOG_PUSH_TOKEN }}
           CATALOG_REPO: ${{ inputs.catalog_repo }}

--- a/.github/workflows/operator-deploy.yaml
+++ b/.github/workflows/operator-deploy.yaml
@@ -10,6 +10,16 @@ on:
         type: string
         required: false
         default: "quay.io/okderators"
+      update_catalog:
+        description: "Open a PR against the catalog index with the built bundle(s)"
+        type: boolean
+        required: false
+        default: true
+      catalog_branch:
+        description: "Catalog index branch to target with the PR"
+        type: string
+        required: false
+        default: "release-4.21"
 
 name: Deploy Operator
 
@@ -17,6 +27,8 @@ jobs:
   deploy-operator:
     name: Deploy Operator
     runs-on: ubuntu-latest
+    outputs:
+      bundle_images: ${{ steps.bundles.outputs.bundle_images }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -62,6 +74,12 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Pin build date
+        # DATE is baked into every image tag by common.sh; pinning it lets
+        # later steps reconstruct the exact image references build.sh pushed
+        # language=bash
+        run: echo "DATE=$(date +%Y-%m-%d-%H%M%S)" >> "$GITHUB_ENV"
+
       - name: Build and push operator
         env:
           NAMESPACE: ${{ inputs.operator }}
@@ -82,6 +100,32 @@ jobs:
 
           echo "Successfully built and pushed ${{ inputs.operator }}"
 
+      - name: Collect bundle image references
+        id: bundles
+        env:
+          NAMESPACE: ${{ inputs.operator }}
+          BASE_REGISTRY: ${{ inputs.base_registry }}
+        # language=bash
+        run: |
+          cd ${{ inputs.operator }}
+
+          # Sourcing build.sh (guarded by BASH_SOURCE, so main() does not run)
+          # re-derives the IMG_BUNDLE* variables with the pinned DATE
+          BUNDLES=$(bash -c 'source ./build.sh >/dev/null 2>&1; for v in $(compgen -v IMG_BUNDLE); do echo "${!v}"; done') || BUNDLES=""
+
+          if [ -z "$BUNDLES" ]; then
+            echo "::warning::Could not determine bundle image references; the catalog PR job will be skipped"
+          else
+            echo "Bundle images:"
+            echo "$BUNDLES"
+          fi
+
+          {
+            echo "bundle_images<<BUNDLES_EOF"
+            echo "$BUNDLES"
+            echo "BUNDLES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create deployment summary
         if: success()
         # language=bash
@@ -96,3 +140,14 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ inputs.base_registry }}/${{ inputs.operator }}/*:*" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  catalog-pr:
+    name: Catalog Index PR
+    needs: deploy-operator
+    if: inputs.update_catalog && needs.deploy-operator.outputs.bundle_images != ''
+    uses: ./.github/workflows/catalog-pr.yaml
+    with:
+      operator: ${{ inputs.operator }}
+      bundle_images: ${{ needs.deploy-operator.outputs.bundle_images }}
+      catalog_branch: ${{ inputs.catalog_branch }}
+    secrets: inherit

--- a/scripts/update-catalog-package.sh
+++ b/scripts/update-catalog-package.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Update (or create) the OLM package YAML of a file-based catalog so that a
+# newly rendered bundle is wired into the channel upgrade graph. This is the
+# companion to okderators-catalog-index's hack/add-bundle.sh, which renders
+# the bundle file but does not touch the olm.package/olm.channel documents.
+#
+# Usage: update-catalog-package.sh <package-file> <bundle-name> [channel]
+#   package-file  catalog/<operator>/<operator>.yaml (inside the catalog repo)
+#   bundle-name   CSV name, e.g. cert-manager-operator.v1.18.0-2025-12-25-214537
+#   channel       channel used when the package file does not exist yet;
+#                 existing files use their defaultChannel (default: alpha)
+#
+# Requires: yq (v4+)
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <package-file> <bundle-name> [channel]"
+  exit 1
+fi
+
+PKG_FILE=$1
+export BUNDLE_NAME=$2
+export CHANNEL=${3:-alpha}
+OPERATOR=$(basename "$PKG_FILE" .yaml)
+
+if [ ! -f "$PKG_FILE" ]; then
+  echo "Creating package file ${PKG_FILE} (defaultChannel: ${CHANNEL})"
+  mkdir -p "$(dirname "$PKG_FILE")"
+  cat > "$PKG_FILE" <<EOF
+---
+schema: olm.package
+name: ${OPERATOR}
+defaultChannel: ${CHANNEL}
+---
+schema: olm.channel
+package: ${OPERATOR}
+name: ${CHANNEL}
+entries:
+  - name: ${BUNDLE_NAME}
+EOF
+  exit 0
+fi
+
+# Existing package: wire the bundle into the default channel
+DEFAULT_CHANNEL=$(yq 'select(.schema == "olm.package") | .defaultChannel' "$PKG_FILE")
+if [ -n "$DEFAULT_CHANNEL" ] && [ "$DEFAULT_CHANNEL" != "null" ]; then
+  CHANNEL=$DEFAULT_CHANNEL
+fi
+export CHANNEL
+
+# Channel document missing entirely: append a fresh one
+if [ -z "$(yq 'select(.schema == "olm.channel" and .name == env(CHANNEL)) | .name' "$PKG_FILE")" ]; then
+  echo "Adding channel ${CHANNEL} with entry ${BUNDLE_NAME} to ${PKG_FILE}"
+  cat >> "$PKG_FILE" <<EOF
+---
+schema: olm.channel
+package: ${OPERATOR}
+name: ${CHANNEL}
+entries:
+  - name: ${BUNDLE_NAME}
+EOF
+  exit 0
+fi
+
+# Entry already present: nothing to do
+if [ -n "$(yq 'select(.schema == "olm.channel" and .name == env(CHANNEL)) | .entries[] | select(.name == env(BUNDLE_NAME)) | .name' "$PKG_FILE")" ]; then
+  echo "${BUNDLE_NAME} is already in channel ${CHANNEL} of ${PKG_FILE}; skipping"
+  exit 0
+fi
+
+PREVIOUS=$(yq 'select(.schema == "olm.channel" and .name == env(CHANNEL)) | .entries[-1].name' "$PKG_FILE")
+export PREVIOUS
+
+# yq -i re-emits the file without a leading document separator; remember
+# whether one was there so the diff stays clean
+HAD_LEADING_SEPARATOR=0
+[ "$(head -n 1 "$PKG_FILE")" = "---" ] && HAD_LEADING_SEPARATOR=1
+
+yq -i '(select(.schema == "olm.channel" and .name == env(CHANNEL)) | .entries) += [{"name": env(BUNDLE_NAME), "replaces": env(PREVIOUS)}]' "$PKG_FILE"
+
+if [ "$HAD_LEADING_SEPARATOR" = "1" ] && [ "$(head -n 1 "$PKG_FILE")" != "---" ]; then
+  sed -i '1i ---' "$PKG_FILE"
+fi
+
+echo "Appended ${BUNDLE_NAME} (replaces ${PREVIOUS}) to channel ${CHANNEL} in ${PKG_FILE}"


### PR DESCRIPTION
Adds a workflow that takes freshly built bundle image(s) and opens a PR against [okderators-catalog-index](https://github.com/okd-project/okderators-catalog-index) adding them to the catalog.

Closes [INFRA-123](https://linear.app/ziax/issue/INFRA-123/github-workflow-pr-a-built-okd-operator-bundle-into-the-okderators)

## What's included

- **`.github/workflows/catalog-pr.yaml`** — reusable (`workflow_call`) + manually dispatchable workflow that:
  - checks out the catalog index on the target release branch (default `release-4.21`)
  - renders each bundle with the catalog repo's own `hack/add-bundle.sh`
  - wires the new bundle into the OLM package/channel upgrade graph (the piece `add-bundle.sh` doesn't handle)
  - validates the result with `opm validate` before proposing anything
  - pushes a branch and opens a PR on the catalog index via `gh`
- **`scripts/update-catalog-package.sh`** — updates or creates `catalog/<operator>/<operator>.yaml`: creates the `olm.package`/`olm.channel` skeleton for new operators, appends new versions to the channel `entries` with `replaces` pointing at the previous latest, and is idempotent on re-runs. Existing packages use their `defaultChannel`; new ones take the `channel` input (default `alpha`).
- **`operator-deploy.yaml`** — pins `DATE` so the bundle tags pushed by `build.sh` can be reconstructed, collects the `IMG_BUNDLE*` references after a successful build, and chains the `catalog-pr` job. Opt out per call with `update_catalog: false`.

## Auth

No PAT: the workflow mints a short-lived installation token with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) from an org-owned GitHub App, scoped to the catalog index repo. It reads the `CATALOG_APP_ID` variable and `CATALOG_APP_PRIVATE_KEY` secret (both already configured). PRs opened with the app token also trigger the catalog repo's CI, unlike the default `GITHUB_TOKEN`.

## Testing

`update-catalog-package.sh` was exercised against the real `cert-manager-operator.yaml` package file: appending a new version (correct `replaces`, minimal diff), re-running with the same bundle (no-op), creating a package file from scratch, and adding a missing channel document.
