### PR TITLE
Fix catalog-pr workflow: app ID lookup, script invocation, registries.conf, package-name derivation

### DIFF
--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -129,7 +129,7 @@ jobs:
           BUNDLE_NAMES=""
           for BUNDLE in $BUNDLE_IMAGES; do
             echo "Rendering ${BUNDLE} into the catalog..."
-            ./hack/add-bundle.sh "$BUNDLE"
+            bash ./hack/add-bundle.sh "$BUNDLE"
 
             # Derive the CSV/bundle name the same way add-bundle.sh does
             BUNDLE_NAME=$(opm render "$BUNDLE" -o yaml | yq 'select(.schema == "olm.bundle") | .name')

--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -111,6 +111,13 @@ jobs:
       - name: Install Podman
         uses: redhat-actions/podman-install@main
 
+      - name: Configure container registries
+        # The runner image ships a v1-format registries.conf; opm's image
+        # library only accepts the v2 format
+        # language=bash
+        run: |
+          printf 'unqualified-search-registries = ["docker.io"]\n' | sudo tee /etc/containers/registries.conf
+
       - name: Configure git
         # language=bash
         run: |

--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -26,8 +26,11 @@ on:
         required: false
         default: "alpha"
     secrets:
+      CATALOG_APP_ID:
+        description: "App ID of the GitHub App used to push branches and open PRs on the catalog index repository"
+        required: false
       CATALOG_APP_PRIVATE_KEY:
-        description: "Private key of the GitHub App used to push branches and open PRs on the catalog index repository (app id comes from the CATALOG_APP_ID variable)"
+        description: "Private key of the GitHub App used to push branches and open PRs on the catalog index repository"
         required: false
   workflow_dispatch:
     inputs:
@@ -81,7 +84,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CATALOG_APP_ID }}
+          app-id: ${{ secrets.CATALOG_APP_ID }}
           private-key: ${{ secrets.CATALOG_APP_PRIVATE_KEY }}
           owner: ${{ steps.catalog.outputs.owner }}
           repositories: ${{ steps.catalog.outputs.name }}

--- a/.github/workflows/catalog-pr.yaml
+++ b/.github/workflows/catalog-pr.yaml
@@ -138,13 +138,17 @@ jobs:
             echo "Rendering ${BUNDLE} into the catalog..."
             bash ./hack/add-bundle.sh "$BUNDLE"
 
-            # Derive the CSV/bundle name the same way add-bundle.sh does
-            BUNDLE_NAME=$(opm render "$BUNDLE" -o yaml | yq 'select(.schema == "olm.bundle") | .name')
-            OPERATOR_NAME=${BUNDLE_NAME%%.*}
+            # The bundle name is its CSV name; the package comes from the
+            # bundle's own package field (the CSV name prefix is not reliable,
+            # e.g. clusterkubedescheduleroperator.vX belongs to package
+            # cluster-kube-descheduler-operator)
+            RENDERED=$(opm render "$BUNDLE" -o yaml)
+            BUNDLE_NAME=$(yq 'select(.schema == "olm.bundle") | .name' <<< "$RENDERED")
+            PACKAGE_NAME=$(yq 'select(.schema == "olm.bundle") | .package' <<< "$RENDERED")
 
             # Wire the new bundle into the package's channel upgrade graph
             bash "$GITHUB_WORKSPACE/scripts/update-catalog-package.sh" \
-              "catalog/${OPERATOR_NAME}/${OPERATOR_NAME}.yaml" "$BUNDLE_NAME" "$CHANNEL"
+              "catalog/${PACKAGE_NAME}/${PACKAGE_NAME}.yaml" "$BUNDLE_NAME" "$CHANNEL"
 
             BUNDLE_NAMES="${BUNDLE_NAMES} ${BUNDLE_NAME}"
           done


### PR DESCRIPTION
Live-testing the catalog-pr workflow from #25 (run [29252125571](https://github.com/okd-project/okd-operator-pipeline/actions/runs/29252125571)) surfaced four failures; this fixes them:

1. **App ID lookup**: `CATALOG_APP_ID` is configured as a repository *secret*, not an Actions *variable*, so `vars.CATALOG_APP_ID` resolved empty and token minting failed with `[@octokit/auth-app] appId option is required`. The workflow now reads `secrets.CATALOG_APP_ID` (declared in the `workflow_call` secrets block; still covered by `secrets: inherit`).
2. **add-bundle.sh invocation**: `hack/add-bundle.sh` is committed without the executable bit in okderators-catalog-index, so direct invocation failed with `Permission denied`. It is now run via `bash`.
3. **registries.conf**: the ubuntu-latest runner ships a v1-format `/etc/containers/registries.conf`, which `opm render` rejects. A minimal v2 config is written after installing Podman.
4. **Package-name derivation**: the CSV name prefix is not a reliable package name — kube-descheduler's CSV is `clusterkubedescheduleroperator.vX` while its package is `cluster-kube-descheduler-operator`, so `opm validate` failed with `unknown package`. The package name is now taken from the rendered bundle's `package` field.

## Testing

Dispatched from this branch with the kube-descheduler bundle built today (`quay.io/okderators/kube-descheduler/operator-bundle:5.4.0-2026-07-13-120312`): [run 29252881733](https://github.com/okd-project/okd-operator-pipeline/actions/runs/29252881733) went green through render, validate, and PR creation, and opened okd-project/okderators-catalog-index#49 via the app token.

Note: okderators-catalog-index#49 shows `hack/add-bundle.sh` still places the bundle YAML in a CSV-prefix-named directory (`catalog/clusterkubedescheduleroperator/`) while the package file lands in `catalog/cluster-kube-descheduler-operator/`. Valid FBC, but the same package-field derivation could be applied to `add-bundle.sh` in the catalog repo for consistent layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)